### PR TITLE
feat!: 配列へコピーする機能追加

### DIFF
--- a/bytes-kotlin/src/main/kotlin/jp/co/gahojin/bytes/ByteArrayStore.kt
+++ b/bytes-kotlin/src/main/kotlin/jp/co/gahojin/bytes/ByteArrayStore.kt
@@ -169,3 +169,7 @@ inline fun ByteArray.putLongLe(index: Int, source: Long) {
 inline fun ByteArray.putLong(index: Int, source: ULong) = putLong(index, source.toLong())
 
 inline fun ByteArray.putLongLe(index: Int, source: ULong) = putLongLe(index, source.toLong())
+
+inline fun ByteArray.put(index: Int, source: Bytes, fromIndex: Int = 0, toIndex: Int = source.size) {
+    source.copyInto(this, index, fromIndex, toIndex)
+}

--- a/bytes-kotlin/src/main/kotlin/jp/co/gahojin/bytes/Bytes.kt
+++ b/bytes-kotlin/src/main/kotlin/jp/co/gahojin/bytes/Bytes.kt
@@ -58,7 +58,7 @@ class Bytes private constructor(
      */
     fun uarray(): UByteArray = storage.asUByteArray()
 
-    fun copyRange(fromIndex: Int, toIndex: Int): Bytes {
+    fun copyOfRange(fromIndex: Int, toIndex: Int): Bytes {
         return Bytes(storage.copyOfRange(fromIndex, toIndex))
     }
 
@@ -84,6 +84,17 @@ class Bytes private constructor(
                 }
             }
         }
+    }
+
+    @JvmOverloads
+    fun copyInto(dest: ByteArray, offset: Int = 0, fromIndex: Int = 0, toIndex: Int = dest.size): Bytes {
+        System.arraycopy(storage, fromIndex, dest, offset, toIndex - fromIndex)
+        return this
+    }
+
+    fun copyInto(dest: UByteArray, offset: Int = 0, fromIndex: Int = 0, toIndex: Int = dest.size): Bytes {
+        System.arraycopy(storage, fromIndex, dest.asByteArray(), offset, toIndex - fromIndex)
+        return this
     }
 
     fun getByte(offset: Int): Byte = storage[offset]

--- a/bytes-kotlin/src/main/kotlin/jp/co/gahojin/bytes/UByteArrayStore.kt
+++ b/bytes-kotlin/src/main/kotlin/jp/co/gahojin/bytes/UByteArrayStore.kt
@@ -73,3 +73,7 @@ inline fun UByteArray.putLongLe(index: Int, source: Long) = asByteArray().putLon
 inline fun UByteArray.putLong(index: Int, source: ULong) = asByteArray().putLong(index, source)
 
 inline fun UByteArray.putLongLe(index: Int, source: ULong) = asByteArray().putLongLe(index, source)
+
+inline fun UByteArray.put(index: Int, source: Bytes, fromIndex: Int = 0, toIndex: Int = source.size) {
+    source.copyInto(this, index, fromIndex, toIndex)
+}

--- a/bytes-kotlin/src/test/kotlin/jp/co/gahojin/bytes/ByteArrayStoreTest.kt
+++ b/bytes-kotlin/src/test/kotlin/jp/co/gahojin/bytes/ByteArrayStoreTest.kt
@@ -3,8 +3,8 @@ package jp.co.gahojin.bytes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.uInt
+import io.kotest.property.arbitrary.*
+import io.kotest.property.arbitrary.uByteArray
 import io.kotest.property.checkAll
 
 class ByteArrayStoreTest : FunSpec({
@@ -157,6 +157,20 @@ class ByteArrayStoreTest : FunSpec({
             val sut = ByteArray(8)
             sut.putLongLe(0, a)
             sut.getULongLe(0) shouldBe a
+        }
+    }
+
+    test("put(Bytes)") {
+        checkAll(Arb.byteArray(Arb.int(min = 10, max = 256), Arb.byte())) { a ->
+            val sut = Bytes.wrap(a)
+            val buf = ByteArray(a.size)
+
+            buf.put(0, sut)
+            buf shouldBe a
+
+            buf.fill(0)
+            buf.put(1, sut, 2, 10)
+            buf.copyOfRange(1, 9) shouldBe a.copyOfRange(2, 10)
         }
     }
 })

--- a/bytes-kotlin/src/test/kotlin/jp/co/gahojin/bytes/BytesTest.kt
+++ b/bytes-kotlin/src/test/kotlin/jp/co/gahojin/bytes/BytesTest.kt
@@ -120,17 +120,17 @@ class BytesTest : FunSpec({
         arr shouldBe ubyteArrayOf(0x07u, 0x08u, 0x09u)
     }
 
-    test("copyRange") {
+    test("copyOfRange") {
         val sut = Bytes.allocate(10) { it.toUByte() }
-        sut.copyRange(0, 5) shouldBe Bytes.from(0x00u, 0x01u, 0x02u, 0x03u, 0x04u)
-        sut.copyRange(2, 5) shouldBe Bytes.from(0x02u, 0x03u, 0x04u)
+        sut.copyOfRange(0, 5) shouldBe Bytes.from(0x00u, 0x01u, 0x02u, 0x03u, 0x04u)
+        sut.copyOfRange(2, 5) shouldBe Bytes.from(0x02u, 0x03u, 0x04u)
 
         // 範囲外
         assertThrows<IndexOutOfBoundsException> {
-            sut.copyRange(2, 11)
+            sut.copyOfRange(2, 11)
         }
         assertThrows<IndexOutOfBoundsException> {
-            sut.copyRange(-1, 4)
+            sut.copyOfRange(-1, 4)
         }
     }
 
@@ -157,6 +157,20 @@ class BytesTest : FunSpec({
         // 範囲外
         assertThrows<NegativeArraySizeException> {
             sut.copyOf(-1)
+        }
+    }
+
+    test("copyInto") {
+        checkAll(Arb.byteArray(Arb.int(min = 2, max = 256), Arb.byte())) { a ->
+            val buf = ByteArray(a.size + 2)
+            val ubuf = UByteArray(a.size + 2)
+            val sut = Bytes.wrap(a)
+
+            sut.copyInto(buf, 2, 1, a.size)
+            buf.copyOfRange(2, a.size + 1) shouldBe a.copyOfRange(1, a.size)
+
+            sut.copyInto(ubuf, 2, 1, a.size)
+            ubuf.copyOfRange(2, a.size + 1) shouldBe a.asUByteArray().copyOfRange(1, a.size)
         }
     }
 

--- a/bytes-kotlin/src/test/kotlin/jp/co/gahojin/bytes/UByteArrayStoreTest.kt
+++ b/bytes-kotlin/src/test/kotlin/jp/co/gahojin/bytes/UByteArrayStoreTest.kt
@@ -3,8 +3,8 @@ package jp.co.gahojin.bytes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.uInt
+import io.kotest.property.arbitrary.*
+import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.checkAll
 
 class UByteArrayStoreTest : FunSpec({
@@ -157,6 +157,20 @@ class UByteArrayStoreTest : FunSpec({
             val sut = UByteArray(8)
             sut.putLongLe(0, a)
             sut.getULongLe(0) shouldBe a
+        }
+    }
+
+    test("put(Bytes)") {
+        checkAll(Arb.uByteArray(Arb.int(min = 10, max = 256), Arb.uByte())) { a ->
+            val sut = Bytes.wrap(a)
+            val buf = UByteArray(a.size)
+
+            buf.put(0, sut)
+            buf shouldBe a
+
+            buf.fill(0u)
+            buf.put(1, sut, 2, 10)
+            buf.copyOfRange(1, 9) shouldBe a.copyOfRange(2, 10)
         }
     }
 })


### PR DESCRIPTION
copyRangeをcopyToRangeにリネーム (ByteArrayの拡張関数と名前が揃っていないため)