### PR TITLE
fix: github actionsの3rd partyのactionをピン留めする

### DIFF
--- a/.github/workflows/assign_author.yml
+++ b/.github/workflows/assign_author.yml
@@ -2,7 +2,7 @@ name: Assign author
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions:
   pull-requests: write
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR
-        uses: technote-space/assign-author@v1
+        uses: toshimaru/auto-author-assign@7e15cd70c245ad136377c3fab3479815df10d844 # v2.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,16 +42,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # 4.6.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
 
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
         with:
           dependency-graph: generate-and-submit
 

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v2
+        uses: gradle-update/update-gradle-wrapper-action@9268373d69bd0974b6318eb3b512b8e025060bbe # v2.0.0


### PR DESCRIPTION
author自動設定actionをtoshimaru/auto-author-assignに変更