### PR TITLE
fix: javadocのjarにjarが入る誤った構成となっていた

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Kotlin向けバイト配列操作ライブラリ
 
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/gahojin/bytes-kotlin/build.yml)](https://github.com/gahojin/bytes-kotlin/actions/workflows/build.yml)
 [![Maven Central Version](https://img.shields.io/maven-central/v/jp.co.gahojin.bytes-kotlin/bytes-kotlin)](https://central.sonatype.com/artifact/jp.co.gahojin.bytes-kotlin/bytes-kotlin)
+[![javadoc](https://javadoc.io/badge2/jp.co.gahojin.bytes-kotlin/bytes-kotlin/javadoc.svg)](https://javadoc.io/doc/jp.co.gahojin.bytes-kotlin/bytes-kotlin)
 [![GitHub License](https://img.shields.io/github/license/gahojin/bytes-kotlin)](LICENSE)
 
 ## Get Started

--- a/bytes-kotlin/build.gradle.kts
+++ b/bytes-kotlin/build.gradle.kts
@@ -78,12 +78,6 @@ tasks.withType<Test>().configureEach {
     }
 }
 
-val dokkaJavadocJar by tasks.registering(Jar::class) {
-    description = "A Javadoc JAR containing Dokka Javadoc"
-    archiveClassifier = "javadoc"
-    from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
-}
-
 signing {
     useGpgCmd()
     sign(publishing.publications)
@@ -91,7 +85,7 @@ signing {
 
 mavenPublishing {
     configure(KotlinJvm(
-        javadocJar = JavadocJar.Dokka("dokkaJavadocJar"),
+        javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationJavadoc"),
         sourcesJar = true,
     ))
 


### PR DESCRIPTION
- READMEにjavadocへのバッジ追加