### PR TITLE
build(deps): dokkaアップデート

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.10" />
+    <option name="version" value="2.2.20" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,19 +7,3 @@ plugins {
     alias(libs.plugins.kotlinx.kover) apply false
     alias(libs.plugins.maven.publish) apply false
 }
-
-// FIXME Dokkaにより、脆弱な依存関係が取り込まれている
-// https://github.com/Kotlin/dokka/issues/3194
-allprojects {
-    configurations.all {
-        resolutionStrategy {
-            force(libs.fastxml.woodstox)
-
-            eachDependency {
-                if (requested.group.startsWith("com.fasterxml.jackson")) {
-                    useVersion("2.15.3")
-                }
-            }
-        }
-    }
-}

--- a/bytes-kotlin/build.gradle.kts
+++ b/bytes-kotlin/build.gradle.kts
@@ -79,6 +79,7 @@ tasks.withType<Test>().configureEach {
 }
 
 signing {
+    isRequired = true
     useGpgCmd()
     sign(publishing.publications)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
-org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,7 @@
 
 detekt = "1.23.8"
 
-dokka = "2.0.0"
-
-fastxml-jackson = "2.15.3"
-
-fastxml-woodstox = "7.1.1"
+dokka = "2.1.0-Beta"
 
 kotest = "6.0.3"
 
@@ -19,10 +15,6 @@ kover = "0.9.2"
 maven-publish = "0.34.0"
 
 [libraries]
-
-fastxml-jackson-bom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "fastxml-jackson" }
-
-fastxml-woodstox = { group = "com.fasterxml.woodstox", name = "woodstox-core", version.ref = "fastxml-woodstox" }
 
 kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("jp.co.gahojin.refreshVersions") version "0.3.0"
+    id("jp.co.gahojin.refreshVersions") version "0.4.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
- dokka 2.1.0-BetaでJackson 2.15.3対応が行われたため、バージョン上書きをやめる