### PR TITLE
境界値テスト、上位ビットが1の時に値が取得出来ないバグ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,45 @@ val result = b.array()
 
 ## API 
 
+### Bytes
+
+`Bytes` クラスは `ByteArray` のラッパーで、ビット操作やエンディアン変換などの便利なメソッドを提供します。
+
+#### パフォーマンスと設計方針
+
+- **ゼロコピー**: `Bytes.wrap(array)` や `Bytes.array()` は内部配列を直接参照します。大規模なデータ操作においてコピーのオーバーヘッドを避け、高いパフォーマンスを実現します。
+- **ミュータブル**: `Bytes` クラスのメソッド（`putInt` 等）は、ラップしている内部配列を直接書き換えます。
+- **正確なビット操作**: 内部的に `Byte` の符号拡張を適切に処理しており、負の値を含むバイト配列でも正しく数値の読み書きが可能です。
+
+#### インスタンスの生成
+
+```kotlin
+// アロケート
+val b1 = Bytes.allocate(10)
+
+// ラップ（元の配列を共有、コピーが発生しない）
+val b3 = Bytes.wrap(byteArrayOf(0x01, 0x02))
+
+// コピーから生成
+val b4 = Bytes.from(0x01.toByte(), 0x02.toByte())
+```
+
+#### 基本操作
+
+```kotlin
+val b = Bytes.allocate(4)
+b.putInt(0, 12345678)
+val i = b.getInt(0)
+val hex = b.toHexString()
+```
+
+#### 配列へのアクセス
+
+```kotlin
+val b = Bytes.allocate(4)
+val ref = b.array()  // 内部配列への参照を返す（変更はbに反映される）
+```
+
 ## License
 
 ```

--- a/lib/src/commonMain/kotlin/jp/co/gahojin/bytes/BaseBytes.kt
+++ b/lib/src/commonMain/kotlin/jp/co/gahojin/bytes/BaseBytes.kt
@@ -38,6 +38,7 @@ abstract class BaseBytes<T : BaseBytes<T>> internal constructor(
                     i++
                     continue
                 }
+
                 byteA < byteB -> -1
                 else -> 1
             }
@@ -56,7 +57,7 @@ abstract class BaseBytes<T : BaseBytes<T>> internal constructor(
     override fun equals(other: Any?): Boolean {
         return when {
             this === other -> true
-            other !is Bytes -> false
+            other !is BaseBytes<*> -> false
             else -> storage.contentEquals(other.storage)
         }
     }

--- a/lib/src/commonMain/kotlin/jp/co/gahojin/bytes/ByteArrayBinary.kt
+++ b/lib/src/commonMain/kotlin/jp/co/gahojin/bytes/ByteArrayBinary.kt
@@ -86,11 +86,13 @@ fun ByteArray.shr(bitCount: Int, inPlace: Boolean = false): ByteArray {
 }
 
 fun ByteArray.getBit(bitIndex: Int): Boolean {
-    return ((this[size - bitIndex / 8 - 1] shr (bitIndex % 8)) and 0x01) != 0
+    require(bitIndex in 0 until (size shl 3)) { "bitIndex $bitIndex out of bounds" }
+    return ((this[size - bitIndex / 8 - 1].uint shr (bitIndex % 8)) and 0x01) != 0
 }
 
 fun ByteArray.getBitLe(bitIndex: Int): Boolean {
-    return ((this[bitIndex / 8] shr (bitIndex % 8)) and 0x01) != 0
+    require(bitIndex in 0 until (size shl 3)) { "bitIndex $bitIndex out of bounds" }
+    return ((this[bitIndex / 8].uint shr (bitIndex % 8)) and 0x01) != 0
 }
 
 fun ByteArray.switchBit(bitIndex: Int, value: Boolean, inPlace: Boolean = false): ByteArray {
@@ -133,7 +135,11 @@ fun ByteArray.flipBitLe(indexRange: IntProgression, inPlace: Boolean = false): B
     return switchBit(indexRange, inPlace, ::getByteIndexLe) { bit, v -> v xor bit }
 }
 
-private inline fun ByteArray.bitWise(second: ByteArray, inPlace: Boolean, block: (a: Byte, b: Byte) -> Byte): ByteArray {
+private inline fun ByteArray.bitWise(
+    second: ByteArray,
+    inPlace: Boolean,
+    block: (a: Byte, b: Byte) -> Byte,
+): ByteArray {
     require(size == second.size) { "must match exactly one of ${second.size} bytes" }
 
     val target = prepareTarget(inPlace)

--- a/lib/src/commonMain/kotlin/jp/co/gahojin/bytes/FromByteArray.kt
+++ b/lib/src/commonMain/kotlin/jp/co/gahojin/bytes/FromByteArray.kt
@@ -1,12 +1,12 @@
 package jp.co.gahojin.bytes
 
 fun ByteArray.getShort(index: Int): Short {
-    val s = (this[index] shl 8) or (this[index + 1].uint)
+    val s = (this[index].uint shl 8) or (this[index + 1].uint)
     return s.toShort()
 }
 
 fun ByteArray.getShortLe(index: Int): Short {
-    val s = (this[index].uint) or (this[index + 1] shl 8)
+    val s = (this[index].uint) or (this[index + 1].uint shl 8)
     return s.toShort()
 }
 
@@ -15,17 +15,17 @@ fun ByteArray.getUShort(index: Int): UShort = getShort(index).toUShort()
 fun ByteArray.getUShortLe(index: Int): UShort = getShortLe(index).toUShort()
 
 fun ByteArray.getInt(index: Int): Int {
-    return (this[index] shl 24) or
-            (this[index + 1] shl 16) or
-            (this[index + 2] shl 8) or
+    return (this[index].uint shl 24) or
+            (this[index + 1].uint shl 16) or
+            (this[index + 2].uint shl 8) or
             (this[index + 3].uint)
 }
 
 fun ByteArray.getIntLe(index: Int): Int {
     return (this[index].uint) or
-            (this[index + 1] shl 8) or
-            (this[index + 2] shl 16) or
-            (this[index + 3] shl 24)
+            (this[index + 1].uint shl 8) or
+            (this[index + 2].uint shl 16) or
+            (this[index + 3].uint shl 24)
 }
 
 fun ByteArray.getInt(index: Int, length: Int): Int {
@@ -43,24 +43,19 @@ fun ByteArray.getUIntLe(index: Int): UInt = getIntLe(index).toUInt()
 fun ByteArray.getUInt(index: Int, length: Int): UInt {
     require(length in 1..4) { "must be between 1 and 4: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
     var tmp = 0
-    for (shift in maxShift downTo 8 step 8) {
-        tmp = tmp or (this[offset++] shl shift)
+    for (i in 0 until length) {
+        tmp = (tmp shl 8) or (this[index + i].uint)
     }
-    tmp = tmp or (this[offset].uint)
     return tmp.toUInt()
 }
 
 fun ByteArray.getUIntLe(index: Int, length: Int): UInt {
     require(length in 1..4) { "must be between 1 and 4: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
-    var tmp = this[offset].uint
-    for (shift in 8 .. maxShift step 8) {
-        tmp = tmp or (this[++offset] shl shift)
+    var tmp = 0
+    for (i in (length - 1) downTo 0) {
+        tmp = (tmp shl 8) or (this[index + i].uint)
     }
     return tmp.toUInt()
 }
@@ -74,16 +69,16 @@ fun ByteArray.getInt24Le(index: Int): Int {
 }
 
 fun ByteArray.getUInt24(index: Int): UInt {
-    val t = (this[index] shl 16) or
-            (this[index + 1] shl 8) or
+    val t = (this[index].uint shl 16) or
+            (this[index + 1].uint shl 8) or
             (this[index + 2].uint)
     return t.toUInt()
 }
 
 fun ByteArray.getUInt24Le(index: Int): UInt {
     val t = (this[index].uint) or
-            (this[index + 1] shl 8) or
-            (this[index + 2] shl 16)
+            (this[index + 1].uint shl 8) or
+            (this[index + 2].uint shl 16)
     return t.toUInt()
 }
 
@@ -114,15 +109,7 @@ fun ByteArray.getLong(index: Int, length: Int): Long {
 }
 
 fun ByteArray.getLongLe(index: Int, length: Int): Long {
-    require(length in 1..8) { "must be between 1 and 8: $length" }
-
-    val maxShift = (length - 1) shl 3
-    var offset = index
-    var tmp = this[offset].ulong
-    for (shift in 8 .. maxShift step 8) {
-        tmp = tmp or (this[++offset].ulong shl shift)
-    }
-    return tmp.unsignedToSigned(length shl 3)
+    return getULongLe(index, length).unsignedToSigned(length shl 3)
 }
 
 fun ByteArray.getULong(index: Int): ULong = getLong(index).toULong()
@@ -132,23 +119,19 @@ fun ByteArray.getULongLe(index: Int): ULong = getLongLe(index).toULong()
 fun ByteArray.getULong(index: Int, length: Int): ULong {
     require(length in 1..8) { "must be between 1 and 8: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
     var tmp = 0L
-    for (shift in maxShift downTo 8 step 8) {
-        tmp = tmp or (this[offset++].ulong shl shift)
+    for (i in 0 until length) {
+        tmp = (tmp shl 8) or (this[index + i].ulong)
     }
-    return (tmp or (this[offset].ulong)).toULong()
+    return tmp.toULong()
 }
 
 fun ByteArray.getULongLe(index: Int, length: Int): ULong {
     require(length in 1..8) { "must be between 1 and 8: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
-    var tmp = this[offset].ulong
-    for (shift in 8 .. maxShift step 8) {
-        tmp = tmp or (this[++offset].ulong shl shift)
+    var tmp = 0L
+    for (i in (length - 1) downTo 0) {
+        tmp = (tmp shl 8) or (this[index + i].ulong)
     }
     return tmp.toULong()
 }
@@ -192,22 +175,16 @@ fun ByteArray.putIntLe(index: Int, source: Int) {
 fun ByteArray.putInt(index: Int, source: Int, length: Int) {
     require(length in 1..4) { "must be between 1 and 4: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
-    for (shift in maxShift downTo 8 step 8) {
-        this[offset++] = (source ushr shift).toByte()
+    for (i in (length - 1) downTo 0) {
+        this[index + i] = (source ushr ((length - 1 - i) shl 3)).toByte()
     }
-    this[offset] = source.toByte()
 }
 
 fun ByteArray.putIntLe(index: Int, source: Int, length: Int) {
     require(length in 1..4) { "must be between 1 and 4: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
-    this[offset] = source.toByte()
-    for (shift in 8 .. maxShift step 8) {
-        this[++offset] = (source ushr shift).toByte()
+    for (i in 0 until length) {
+        this[index + i] = (source ushr (i shl 3)).toByte()
     }
 }
 
@@ -260,22 +237,16 @@ fun ByteArray.putLongLe(index: Int, source: Long) {
 fun ByteArray.putLong(index: Int, source: Long, length: Int) {
     require(length in 1..8) { "must be between 1 and 8: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
-    for (shift in maxShift downTo 8 step 8) {
-        this[offset++] = (source ushr shift).toByte()
+    for (i in (length - 1) downTo 0) {
+        this[index + i] = (source ushr ((length - 1 - i) shl 3)).toByte()
     }
-    this[offset] = source.toByte()
 }
 
 fun ByteArray.putLongLe(index: Int, source: Long, length: Int) {
     require(length in 1..8) { "must be between 1 and 8: $length" }
 
-    val maxShift = (length - 1) shl 3
-    var offset = index
-    this[offset] = source.toByte()
-    for (shift in 8 .. maxShift step 8) {
-        this[++offset] = (source ushr shift).toByte()
+    for (i in 0 until length) {
+        this[index + i] = (source ushr (i shl 3)).toByte()
     }
 }
 

--- a/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/ByteArrayBinaryTest.kt
+++ b/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/ByteArrayBinaryTest.kt
@@ -104,6 +104,9 @@ class ByteArrayBinaryTest : FunSpec({
         sut.shl(1, true) shouldBe byteArrayOf(0xfe.toByte(), 0x01, 0x4a)
         sut shouldBe byteArrayOf(0xfe.toByte(), 0x01, 0x4a)
 
+        // 大きなシフト
+        byteArrayOf(0x01, 0x02, 0x03) shl 24 shouldBe byteArrayOf(0x00, 0x00, 0x00)
+        byteArrayOf(0x01, 0x02, 0x03) shl 8 shouldBe byteArrayOf(0x02, 0x03, 0x00)
     }
 
     test("shr") {
@@ -124,6 +127,10 @@ class ByteArrayBinaryTest : FunSpec({
         // 上書きされていること
         sut.shr(1, true) shouldBe byteArrayOf(0x7f, 0x80.toByte(), 0x52)
         sut shouldBe byteArrayOf(0x7f, 0x80.toByte(), 0x52)
+
+        // 大きなシフト
+        byteArrayOf(0x01, 0x02, 0x03) shr 24 shouldBe byteArrayOf(0x00, 0x00, 0x00)
+        byteArrayOf(0x01, 0x02, 0x03) shr 8 shouldBe byteArrayOf(0x00, 0x01, 0x02)
     }
 
     test("getBit") {
@@ -133,6 +140,10 @@ class ByteArrayBinaryTest : FunSpec({
         sut.getBit(1) shouldBe true
         sut.getBit(4) shouldBe false
         sut.getBit(8) shouldBe true
+        sut.getBit(15) shouldBe true
+
+        shouldThrow<IllegalArgumentException> { sut.getBit(-1) }
+        shouldThrow<IllegalArgumentException> { sut.getBit(16) }
     }
 
     test("getBitLe") {
@@ -142,6 +153,10 @@ class ByteArrayBinaryTest : FunSpec({
         sut.getBitLe(1) shouldBe true
         sut.getBitLe(4) shouldBe false
         sut.getBitLe(8) shouldBe false
+        sut.getBitLe(15) shouldBe false
+
+        shouldThrow<IllegalArgumentException> { sut.getBitLe(-1) }
+        shouldThrow<IllegalArgumentException> { sut.getBitLe(16) }
     }
 
     test("switchBit") {

--- a/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/BytesTest.kt
+++ b/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/BytesTest.kt
@@ -7,7 +7,11 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.*
+import io.kotest.property.arbitrary.byte
+import io.kotest.property.arbitrary.byteArray
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.uByte
+import io.kotest.property.arbitrary.uByteArray
 import io.kotest.property.checkAll
 import kotlin.random.Random
 import kotlin.random.nextUBytes
@@ -39,6 +43,7 @@ class BytesTest : FunSpec({
         val sut = Bytes.from(0x01u, 0x02u, 0x03u)
         sut.containsAll(listOf(0x02, 0x01)) shouldBe true
         sut.containsAll(listOf(0x02, 0x04)) shouldBe false
+        sut.containsAll(emptyList()) shouldBe true
     }
 
     test("contains") {
@@ -118,6 +123,14 @@ class BytesTest : FunSpec({
         }
         // 0 size
         Bytes.allocate(0).equals(Bytes.empty()) shouldBe true
+
+        // 同じ内容あが、異なる型の場合、同じと見なされるか (BaseBytesでチェックしているか)
+        val b1 = Bytes.allocate(4, 0x01.toByte())
+        val b2 = object : BaseBytes<Bytes>(byteArrayOf(0x01, 0x01, 0x01, 0x01)) {
+            override fun create(storage: ByteArray) = b1
+            override val self = b1
+        }
+        b1.equals(b2) shouldBe true
     }
 
     test("contentEquals") {

--- a/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/ResizeTest.kt
+++ b/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/ResizeTest.kt
@@ -30,6 +30,20 @@ class ResizeTest : FunSpec({
             ) shouldBe ByteArray(20) { if (it < 10) it.toByte() else 0x00 }
             sut.copyOf(20, ResizeStrategy.MAX_LENGTH) shouldBe ByteArray(20) { maxOf(0, it - 10).toByte() }
 
+            // strategy 別の挙動 (size=3 -> newSize=5)
+            // ZERO_INDEX: [1, 2, 3, 0, 0]
+            // MAX_LENGTH: [0, 0, 1, 2, 3]
+            val s3 = byteArrayOf(0x01, 0x02, 0x03)
+            s3.copyOf(5, ResizeStrategy.ZERO_INDEX) shouldBe byteArrayOf(0x01, 0x02, 0x03, 0x00, 0x00)
+            s3.copyOf(5, ResizeStrategy.MAX_LENGTH) shouldBe byteArrayOf(0x00, 0x00, 0x01, 0x02, 0x03)
+
+            // strategy 別の挙動 (size=5 -> newSize=3)
+            // ZERO_INDEX: [0, 1, 2]
+            // MAX_LENGTH: [2, 3, 4]
+            val s5 = byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04)
+            s5.copyOf(3, ResizeStrategy.ZERO_INDEX) shouldBe byteArrayOf(0x00, 0x01, 0x02)
+            s5.copyOf(3, ResizeStrategy.MAX_LENGTH) shouldBe byteArrayOf(0x02, 0x03, 0x04)
+
             // 範囲外
             shouldThrow<IllegalArgumentException> {
                 sut.copyOf(-1, ResizeStrategy.MAX_LENGTH)

--- a/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/UByteArrayBinaryTest.kt
+++ b/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/UByteArrayBinaryTest.kt
@@ -105,6 +105,9 @@ class UByteArrayBinaryTest : FunSpec({
         sut.shl(1, true) shouldBe ubyteArrayOf(0xfeu, 0x01u, 0x4au)
         sut shouldBe ubyteArrayOf(0xfeu, 0x01u, 0x4au)
 
+        // 大きなシフト
+        ubyteArrayOf(0x01u, 0x02u, 0x03u) shl 24 shouldBe ubyteArrayOf(0x00u, 0x00u, 0x00u)
+        ubyteArrayOf(0x01u, 0x02u, 0x03u) shl 8 shouldBe ubyteArrayOf(0x02u, 0x03u, 0x00u)
     }
 
     test("shr") {
@@ -125,6 +128,10 @@ class UByteArrayBinaryTest : FunSpec({
         // 上書きされていること
         sut.shr(1, true) shouldBe ubyteArrayOf(0x7fu, 0x80u, 0x52u)
         sut shouldBe ubyteArrayOf(0x7fu, 0x80u, 0x52u)
+
+        // 大きなシフト
+        ubyteArrayOf(0x01u, 0x02u, 0x03u) shr 24 shouldBe ubyteArrayOf(0x00u, 0x00u, 0x00u)
+        ubyteArrayOf(0x01u, 0x02u, 0x03u) shr 8 shouldBe ubyteArrayOf(0x00u, 0x01u, 0x02u)
     }
 
     test("getBit") {
@@ -134,6 +141,10 @@ class UByteArrayBinaryTest : FunSpec({
         sut.getBit(1) shouldBe true
         sut.getBit(4) shouldBe false
         sut.getBit(8) shouldBe true
+        sut.getBit(15) shouldBe true
+
+        shouldThrow<IllegalArgumentException> { sut.getBit(-1) }
+        shouldThrow<IllegalArgumentException> { sut.getBit(16) }
     }
 
     test("getBitLe") {

--- a/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/UtilTest.kt
+++ b/lib/src/commonTest/kotlin/jp/co/gahojin/bytes/UtilTest.kt
@@ -30,7 +30,7 @@ class UtilTest : FunSpec({
         sut shl 2 shouldBe 0x0294u
     }
 
-   test("UByte.shr") {
+    test("UByte.shr") {
         val sut: UByte = 0xa5u
         sut shr 1 shouldBe 0x52u
         sut shr 2 shouldBe 0x29u
@@ -53,8 +53,12 @@ class UtilTest : FunSpec({
         }
 
         checkAll<Short> { a ->
-            a.toInt().unsignedToSigned(16) shouldBe a
+            a.toInt().unsignedToSigned(16) shouldBe a.toInt()
         }
+
+        0xFF.unsignedToSigned(8) shouldBe -1
+        0x7F.unsignedToSigned(8) shouldBe 127
+        0x80.unsignedToSigned(8) shouldBe -128
     }
 
     test("Long.unsignedToSigned") {
@@ -64,7 +68,11 @@ class UtilTest : FunSpec({
         }
 
         checkAll<Int> { a ->
-            a.toLong().unsignedToSigned(32) shouldBe a
+            a.toLong().unsignedToSigned(32) shouldBe a.toLong()
         }
+
+        0xFFL.unsignedToSigned(8) shouldBe -1L
+        0x7FL.unsignedToSigned(8) shouldBe 127L
+        0x80L.unsignedToSigned(8) shouldBe -128L
     }
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `Bytes` の使い方と設計方針を README に追記し、生成・ラップ・変換・16進表示の例を追加しました。

* **Bug Fixes**
  * ビット取得や数値変換での符号拡張の影響を抑え、より正確な結果になるよう改善しました。
  * 範囲外のビットアクセスは明確にエラーになるようになりました。
  * 一部の比較処理の挙動を調整しました。

* **Tests**
  * 大きなシフト量、境界値、空配列、サイズ変更のケースを含むテストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->